### PR TITLE
[Feat] 회원 탈퇴 기능 완성

### DIFF
--- a/src/main/java/api/goorm/map/application/search/api/SearchController.java
+++ b/src/main/java/api/goorm/map/application/search/api/SearchController.java
@@ -3,11 +3,14 @@ package api.goorm.map.application.search.api;
 import api.goorm.map.application.search.dto.SearchRequestDto;
 import api.goorm.map.application.search.dto.SearchResponseDto;
 import api.goorm.map.application.search.service.SearchService;
+import api.goorm.map.application.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/search")
@@ -16,11 +19,19 @@ import org.springframework.web.bind.annotation.*;
 public class SearchController {
 
     private final SearchService searchService;
+    private final UserService userService;
 
     @Operation(summary = "검색 기록 저장", description = "사용자가 검색한 장소를 저장합니다.")
     @PostMapping("/location")
     public ResponseEntity<SearchResponseDto> updateSearch(@RequestBody SearchRequestDto dto) {
-        SearchResponseDto searchResponseDto = searchService.save(dto);
+        SearchResponseDto searchResponseDto = searchService.save(dto, userService.getCurrentUser());
         return ResponseEntity.ok(searchResponseDto);
+    }
+
+    @Operation(summary = "검색 기록 조회", description = "최근 5건이 조회됩니다.")
+    @PostMapping("/get")
+    public ResponseEntity<List<SearchResponseDto>> getSearch() {
+        List<SearchResponseDto> searches = searchService.getSearchList(userService.getCurrentUser());
+        return ResponseEntity.ok(searches);
     }
 }

--- a/src/main/java/api/goorm/map/application/search/dao/SearchRepository.java
+++ b/src/main/java/api/goorm/map/application/search/dao/SearchRepository.java
@@ -3,5 +3,11 @@ package api.goorm.map.application.search.dao;
 import api.goorm.map.application.search.entity.Search;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SearchRepository extends JpaRepository<Search, Long> {
+
+    List<Search> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Long deleteByUserId(Long userId);
 }

--- a/src/main/java/api/goorm/map/application/search/entity/Search.java
+++ b/src/main/java/api/goorm/map/application/search/entity/Search.java
@@ -4,6 +4,8 @@ import api.goorm.map.application.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @Entity
@@ -20,7 +22,14 @@ public class Search {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "location_id")
     private Location location;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/api/goorm/map/application/search/entity/Search.java
+++ b/src/main/java/api/goorm/map/application/search/entity/Search.java
@@ -22,7 +22,7 @@ public class Search {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     private Location location;
 

--- a/src/main/java/api/goorm/map/application/user/api/UserController.java
+++ b/src/main/java/api/goorm/map/application/user/api/UserController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,5 +35,14 @@ public class UserController {
     ) {
         Long id = userService.updateUsername(username);
         return ApiResponse.createSuccess(id);
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "탈퇴시 검색 기록 저장 여부를 결정할 수 있습니다.")
+    @DeleteMapping("/delete")
+    public ResponseEntity<Long> deleteUser(
+            @RequestParam(defaultValue = "false") boolean keepSearchHistory
+    ) {
+        Long id = userService.deleteUser(keepSearchHistory);
+        return ResponseEntity.ok(id);
     }
 }

--- a/src/main/java/api/goorm/map/application/user/dao/UserRepository.java
+++ b/src/main/java/api/goorm/map/application/user/dao/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByKakaoId(String kakaoId);
+    Optional<User> findByKakaoId(String email);
+
+    Optional<User> findByKakaoIdAndActiveFalse(String kakaoId);
 }

--- a/src/main/java/api/goorm/map/application/user/entity/User.java
+++ b/src/main/java/api/goorm/map/application/user/entity/User.java
@@ -26,4 +26,7 @@ public class User {
 
     @Column(unique = true)
     private String email;
+
+    @Column(nullable = false)
+    private boolean active = true;
 }

--- a/src/main/java/api/goorm/map/common/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/api/goorm/map/common/auth/filter/JwtAuthenticationFilter.java
@@ -22,7 +22,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String accessToken = getTokenFromRequest(request);
+        String accessToken = getTokenFromRequest(request) == null ? getTokenFromRequestBearer(request) : getTokenFromRequest(request);
         if (accessToken != null) {
             if (jwtTokenProvider.validateToken(accessToken)) {
                 if (jwtTokenProvider.isTokenExpired(accessToken)) {
@@ -59,6 +59,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return cookie.getValue();
                 }
             }
+        }
+        return null;
+    }
+
+    // Swgger 테스트 시에 사용합니다.
+    private String getTokenFromRequestBearer(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 부분 제거
         }
         return null;
     }

--- a/src/main/java/api/goorm/map/common/config/SwaggerConfig.java
+++ b/src/main/java/api/goorm/map/common/config/SwaggerConfig.java
@@ -14,22 +14,24 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components().addSecuritySchemes("cookieAuth", cookieSecurityScheme()))
+                .components(new Components().addSecuritySchemes("bearerAuth", bearerSecurityScheme()))
                 .info(apiInfo())
-                .addSecurityItem(new SecurityRequirement().addList("cookieAuth"));
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
 
-    private SecurityScheme cookieSecurityScheme() {
+    private SecurityScheme bearerSecurityScheme() {
         return new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
-                .in(SecurityScheme.In.COOKIE)
-                .name("AccessToken");
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
     }
 
     private Info apiInfo() {
         return new Info()
                 .title("산책")
-                .description("GOORM KYONGGI UNIV TEAM 1 - 산책 REST API")
+                .description("산책 API DOCS")
                 .version("1.0.0");
     }
 }


### PR DESCRIPTION
### 기능
사용자 정보를 완전히 삭제할 것인지 체크하고 회원 탈퇴를 하게 되면 -> `Search`, `Location`, `User`가 전부 삭제됩니다.
그렇지 않으면 -> `User`엔티티의 `active` 칼럼이 `false`로 변경되고, 검색 기록 및 장소는 유지됩니다.

따라서 재가입 시에는 `active` 칼럼이 `true`로만 변경되면서 탈퇴 이전의 검색 기록을 다시 사용할 수 있게 됩니다.

그리고, 검색 기록 사용을 위해 검색 기록 조회 API를 구현했습니다.

### 테스트
- 검색 기록 5개 조회
<img width="333" alt="스크린샷 2024-10-19 오후 9 51 44" src="https://github.com/user-attachments/assets/e4d44ec5-917b-425b-9284-c63fd4ed7425">

- 검색기록 유지 옵션이 true일 때 -> 기록이 남아있는 것을 볼 수 있습니다
<img width="136" alt="스크린샷 2024-10-19 오후 10 03 33" src="https://github.com/user-attachments/assets/5bf3e71d-6ad8-475d-9ebe-ad639af0a7f3">
<img width="660" alt="스크린샷 2024-10-19 오후 10 07 23" src="https://github.com/user-attachments/assets/80513664-acea-4156-9341-52b817611c41">


