### PR TITLE
[Refactor] 쿠키 삭제 로직 작성 완료

### DIFF
--- a/src/main/java/api/goorm/map/application/user/api/UserController.java
+++ b/src/main/java/api/goorm/map/application/user/api/UserController.java
@@ -2,10 +2,13 @@ package api.goorm.map.application.user.api;
 
 import api.goorm.map.application.user.dto.UserResponseDto;
 import api.goorm.map.application.user.service.UserService;
+import api.goorm.map.common.config.UrlProperties;
 import api.goorm.map.common.util.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final UrlProperties urlProperties;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 내 정보를 조회합니다.")
     @GetMapping("/my")
@@ -40,9 +44,27 @@ public class UserController {
     @Operation(summary = "회원 탈퇴", description = "탈퇴시 검색 기록 저장 여부를 결정할 수 있습니다.")
     @DeleteMapping("/delete")
     public ResponseEntity<Long> deleteUser(
+            HttpServletResponse response,
             @RequestParam(defaultValue = "false") boolean keepSearchHistory
     ) {
         Long id = userService.deleteUser(keepSearchHistory);
+
+        deleteCookie(response, "AccessToken");
+        deleteCookie(response, "RefreshToken");
+
         return ResponseEntity.ok(id);
+    }
+
+    private void deleteCookie(HttpServletResponse response, String cookieName) {
+        ResponseCookie cookie = ResponseCookie.from(cookieName, "")
+                .maxAge(0)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .domain(urlProperties.getDomain())
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 }


### PR DESCRIPTION
- 회원탈퇴, 로그아웃 api에 쿠키 삭제 로직을 적용했습니다.

`deleteCookie`를 통해 `AccessToken`과 `RefreshToken`의 `maxAge`를 0으로 설정하고, 내용을 빈 값으로 대체합니다.

로컬에서 테스트가 불가능하기도 하고, 테스트 서버가 없기도 해서 쿠키 삭제가 잘 이뤄지는지는 배포 후 테스트 해봐야 할 것 같습니다